### PR TITLE
デフォルトのフォント変更

### DIFF
--- a/src/mui.css
+++ b/src/mui.css
@@ -1,0 +1,4 @@
+.sampleFont {
+  color: #999;
+  font-family: 'Hoefler Text', Georgia, serif;
+}

--- a/src/rich-text-editor.js
+++ b/src/rich-text-editor.js
@@ -1,25 +1,22 @@
 import MUIRichTextEditor from 'mui-rte'
-import DoneIcon from '@material-ui/icons/Done'
-import { EditorState } from 'draft-js'
+import './mui.css';
 
 export default function RichTextEditor() {
 
+    function myBlockStyleFn(contentBlock) {
+        const type = contentBlock.getType();
+        console.log(type)
+        if (type === 'unstyled') {
+            return 'sampleFont';
+        }
+    }
     return (
-
         <MUIRichTextEditor
-            controls={["title"]}
             toolbarButtonSize={"small"}
-            customControls={[
+            draftEditorProps={
                 {
-                    name: "my-callback",
-                    icon: <DoneIcon />,
-                    type: "callback",
-                    onClick: (editorState, name, anchor) => {
-                        console.log(`Clicked ${name} control`)
-                        return EditorState.createEmpty()
-                    }
-                }
-            ]}
+                    blockStyleFn:  myBlockStyleFn,
+                }}
         />
     )
 }


### PR DESCRIPTION
まさにドキュメントにあるようにdraftEditorPropsはdraftjsのEditorコンポーネントのプロップを渡せるので、draftjsのドキュメントを参考にして以下のようにデフォルトのフォントを変更できました。

![image](https://user-images.githubusercontent.com/45054071/131091565-fb613c7f-570d-493e-8c45-c43267787131.png)


参考
https://draftjs.org/docs/advanced-topics-block-styling/#blockstylefn

追加したmui.cssのフォントをいじればデフォルトのフォントを変更できるかと思います。
